### PR TITLE
Added SetIdleMinutes and SetMaxRetries to IMailFolderMonitor.

### DIFF
--- a/source/MailKitSimplified.Receiver/Abstractions/IMailFolderMonitor.cs
+++ b/source/MailKitSimplified.Receiver/Abstractions/IMailFolderMonitor.cs
@@ -1,4 +1,5 @@
 ﻿using MailKit;
+using MailKitSimplified.Receiver.Models;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -7,6 +8,20 @@ namespace MailKitSimplified.Receiver.Abstractions
 {
     public interface IMailFolderMonitor
     {
+        /// <summary>
+        /// Specify length of time to idle for, default is 9 minutes.
+        /// </summary>
+        /// <param name="idleMinutes"></param>
+        /// <returns><see cref="IMailFolderMonitor"/> with <see cref="FolderMonitorOptions.IdleMinutes"/> configured.</returns>
+        IMailFolderMonitor SetIdleMinutes(byte idleMinutes = FolderMonitorOptions.IdleMinutesImap);
+
+        /// <summary>
+        /// Specify number of times to retry on failure, default is 3 times.
+        /// </summary>
+        /// <param name="maxRetries"></param>
+        /// <returns><see cref="IMailFolderMonitor"/> with <see cref="FolderMonitorOptions.MaxRetries"/> configured.</returns>
+        IMailFolderMonitor SetMaxRetries(byte maxRetries = 1);
+
         /// <summary>
         /// Ignore existing messages, processing emails on connect is enabled by default.
         /// </summary>

--- a/source/MailKitSimplified.Receiver/Services/MailFolderMonitor.cs
+++ b/source/MailKitSimplified.Receiver/Services/MailFolderMonitor.cs
@@ -1,19 +1,19 @@
 ﻿using MailKit;
-using MailKit.Security;
 using MailKit.Net.Imap;
+using MailKit.Security;
+using MailKitSimplified.Receiver.Abstractions;
+using MailKitSimplified.Receiver.Extensions;
+using MailKitSimplified.Receiver.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
 using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
 using System.IO;
 using System.Net.Sockets;
 using System.Threading;
 using System.Threading.Tasks;
-using System.Collections.Generic;
-using System.Collections.Concurrent;
-using Microsoft.Extensions.Options;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Logging.Abstractions;
-using MailKitSimplified.Receiver.Abstractions;
-using MailKitSimplified.Receiver.Extensions;
-using MailKitSimplified.Receiver.Models;
 
 namespace MailKitSimplified.Receiver
 {
@@ -54,13 +54,13 @@ namespace MailKitSimplified.Receiver
             };
         }
 
-        public MailFolderMonitor SetIdleMinutes(byte idleMinutes = FolderMonitorOptions.IdleMinutesImap)
+        public IMailFolderMonitor SetIdleMinutes(byte idleMinutes = FolderMonitorOptions.IdleMinutesImap)
         {
             _folderMonitorOptions.IdleMinutes = idleMinutes;
             return this;
         }
 
-        public MailFolderMonitor SetMaxRetries(byte maxRetries = 1)
+        public IMailFolderMonitor SetMaxRetries(byte maxRetries = 1)
         {
             _folderMonitorOptions.MaxRetries = maxRetries;
             return this;
@@ -186,7 +186,7 @@ namespace MailKitSimplified.Receiver
                 }
             }
         }
-        
+
         private async ValueTask ReconnectAsync(CancellationToken cancellationToken = default)
         {
             if (!cancellationToken.IsCancellationRequested)


### PR DESCRIPTION
Hi, @danzuep. I started studying your code for Idle Imap and got an error that the **SetIdleMinutes** and **SetMaxRetries** methods are not in the **IMailFolderMonitor** interface. So I added them there and [this sample](https://github.com/danzuep/MailKitSimplified/wiki/Receiver#mail-folder-idle-monitor) now works. 