### PR TITLE
Dispose of IImapReceiver from IMailFolderReader

### DIFF
--- a/source/MailKitSimplified.Receiver/Abstractions/IMailFolderReader.cs
+++ b/source/MailKitSimplified.Receiver/Abstractions/IMailFolderReader.cs
@@ -1,12 +1,13 @@
 ﻿using MailKit;
 using MimeKit;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Collections.Generic;
 
 namespace MailKitSimplified.Receiver.Abstractions
 {
-    public interface IMailFolderReader : IMailReader
+    public interface IMailFolderReader : IMailReader, IAsyncDisposable, IDisposable
     {
         /// <summary>
         /// Get message summaries with just the requested items filled in for the specified unique IDs.

--- a/source/MailKitSimplified.Receiver/Services/MailFolderReader.cs
+++ b/source/MailKitSimplified.Receiver/Services/MailFolderReader.cs
@@ -256,5 +256,9 @@ namespace MailKitSimplified.Receiver.Services
         public IMailFolderReader Copy() => MemberwiseClone() as IMailFolderReader;
 
         public override string ToString() => $"{_imapReceiver} (skip {_skip}, take {_take})";
+
+        public async ValueTask DisposeAsync() => await _imapReceiver.DisconnectAsync(CancellationToken.None).ConfigureAwait(false);
+
+        public void Dispose() => _imapReceiver?.Dispose();
     }
 }

--- a/tests/MailKitSimplified.Receiver.Tests/MailFolderReaderUnitTests.cs
+++ b/tests/MailKitSimplified.Receiver.Tests/MailFolderReaderUnitTests.cs
@@ -20,6 +20,22 @@ namespace MailKitSimplified.Receiver.Tests
             _mailFolderReader = new MailFolderReader(_imapReceiverMock.Object);
         }
 
+        [Fact]
+        public void Dispose_UsingMailFolderReader()
+        {
+            using var mailFolderReader = new MailFolderReader(_imapReceiverMock.Object);
+            mailFolderReader.Dispose();
+            Assert.NotNull(mailFolderReader);
+            Assert.IsAssignableFrom<IMailFolderReader>(mailFolderReader);
+        }
+
+        [Fact]
+        public async Task DisposeAsync_WithMailFolderReader()
+        {
+            using var mailFolderReader = new MailFolderReader(_imapReceiverMock.Object);
+            await mailFolderReader.DisposeAsync();
+            Assert.IsAssignableFrom<IMailFolderReader>(mailFolderReader);
+        }
 
         [Fact]
         public void Copy_ReturnsShallowCopy()


### PR DESCRIPTION
https://github.com/q00Dree pointed out that MailFolderReader should be disposable.