### PR TITLE
Add DefaultFrom

### DIFF
--- a/source/MailKitSimplified.Sender/Abstractions/IEmailWriter.cs
+++ b/source/MailKitSimplified.Sender/Abstractions/IEmailWriter.cs
@@ -17,6 +17,14 @@ namespace MailKitSimplified.Sender.Abstractions
     public interface IEmailWriter
     {
         /// <summary>
+        /// Set a default sender's details and add to the email.
+        /// </summary>
+        /// <param name="name">Name of sender.</param>
+        /// <param name="address">Email address of sender.</param>
+        /// <returns><see cref="IEmailWriter"/> interface.</returns>
+        IEmailWriter DefaultFrom(string name, string address);
+
+        /// <summary>
         /// Add a sender's details to the email.
         /// </summary>
         /// <param name="name">Name of sender.</param>

--- a/source/MailKitSimplified.Sender/Abstractions/ISmtpSender.cs
+++ b/source/MailKitSimplified.Sender/Abstractions/ISmtpSender.cs
@@ -24,6 +24,11 @@ namespace MailKitSimplified.Sender.Abstractions
         ISmtpClient SmtpClient { get; }
 
         /// <summary>
+        /// Get a default sender's details from the configuration file.
+        /// </summary>
+        MailboxAddress DefaultFrom { get; }
+
+        /// <summary>
         /// Connect and authenticate the SMTP client.
         /// </summary>
         /// <param name="cancellationToken">Stop connecting the client.</param>

--- a/source/MailKitSimplified.Sender/Models/EmailSenderOptions.cs
+++ b/source/MailKitSimplified.Sender/Models/EmailSenderOptions.cs
@@ -9,6 +9,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.ComponentModel.DataAnnotations;
+using MimeKit;
 
 namespace MailKitSimplified.Sender.Models
 {
@@ -25,6 +26,8 @@ namespace MailKitSimplified.Sender.Models
         public string ProtocolLog { get; set; } = null;
         public bool ProtocolLogFileAppend { get; set; } = false;
         public TimeSpan Timeout { get; set; } = TimeSpan.FromMinutes(1);
+
+        public MailboxAddress DefaultFrom { get; set; } = null;
 
         // Constructor required for Configuration mapping.
         public EmailSenderOptions() { }

--- a/source/MailKitSimplified.Sender/Services/EmailWriter.cs
+++ b/source/MailKitSimplified.Sender/Services/EmailWriter.cs
@@ -35,6 +35,9 @@ namespace MailKitSimplified.Sender.Services
             _logger = logger ?? NullLogger<EmailWriter>.Instance;
             _emailClient = emailClient ?? throw new ArgumentNullException(nameof(emailClient));
             _fileSystem = fileSystem ?? new FileSystem();
+            _defaultFrom = emailClient.DefaultFrom != null && !string.IsNullOrEmpty(emailClient.DefaultFrom.Address)
+                ? emailClient.DefaultFrom
+                : null;
         }
 
         public IEmailWriter DefaultFrom(string name, string address)

--- a/source/MailKitSimplified.Sender/Services/SmtpSender.cs
+++ b/source/MailKitSimplified.Sender/Services/SmtpSender.cs
@@ -195,6 +195,8 @@ namespace MailKitSimplified.Sender.Services
 
         public ISmtpClient SmtpClient => _smtpClient;
 
+        public MailboxAddress DefaultFrom => _senderOptions.DefaultFrom;
+
         public async ValueTask<ISmtpClient> ConnectSmtpClientAsync(CancellationToken cancellationToken = default) =>
             await GetConnectedAuthenticatedAsync(cancellationToken).ConfigureAwait(false);
 


### PR DESCRIPTION
1 : Add DefaultFrom method missing in IEmailWriter interface.
2 : Add the DefaultFrom attribute to EmailSenderOptions, and you can use the "await _writeEmail.To("test@localhost").SendAsync();" method directly without using the From method.